### PR TITLE
chore: bump GitHub Actions to latest + Node 24

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22.x, 24.x]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
@@ -28,19 +28,19 @@ jobs:
         cache: 'yarn'
     - name: Cache Puppeteer (Linux)
       if: runner.os == 'Linux'
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}
     - name: Cache Puppeteer (macOS)
       if: runner.os == 'macOS'
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/Library/Caches/puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}
     - name: Cache Puppeteer (Windows)
       if: runner.os == 'Windows'
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~\AppData\Local\puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}


### PR DESCRIPTION
Mechanical bump of GitHub Actions to current latest and (where applicable) extend Node matrix to include 24.x. See commit message for details. Auto-generated across receptron/* + isamu/* source repos. CI on this PR is the verification.